### PR TITLE
Add E39 Support

### DIFF
--- a/Arduino Code/E39_Cluster_SimHub/E39_Cluster_SimHub.ino
+++ b/Arduino Code/E39_Cluster_SimHub/E39_Cluster_SimHub.ino
@@ -1,0 +1,184 @@
+// Refactored Arduino code for SimHub integration with strict input validation
+#include <SPI.h>
+#include <mcp2515.h>
+#include "constants.h"
+#include "pin_definitions.h"
+#include <CustomSoftwareSerial.h>
+#include "cluster_control_functions.h"
+
+MCP2515 CAN(CS_PIN);
+CustomSoftwareSerial kbus(255, K_BUS_PIN);
+
+// Core cluster data
+float rpm = 0;
+float throttle = 0;
+int speed_kmh = 0;
+int temp_c = 0;
+uint8_t fuel_percent = 50;
+char gear = 'P';
+
+// Ignition & electrical state
+bool ignition_on = false;
+bool accessory_on = false;
+
+// Warning & status lights
+bool abs_warning = false;
+bool airbag_warning = false;
+bool parking_brake_engaged = true;
+bool engine_light = false;
+bool cruise_control = false;
+bool eml_warning = false;
+bool gas_cap_warning = false;
+bool high_temp_warning = false;
+bool oil_warning = false;
+bool battery_warning = false;
+bool gearbox_present = true;
+bool asc_enabled = false;
+
+// Light indicators
+bool high_beam, fog_rear, fog_front;
+bool blinker_left, blinker_right;
+bool tail_right, tail_left;
+bool head_right, head_left;
+bool interior_light, light_switch;
+
+String serialBuffer = "";
+unsigned long last_kbus_update = 0;
+unsigned long last_can_update = 0;
+
+void setup() {
+  pinMode(PARKING_BRAKE_PIN, OUTPUT);
+  pinMode(ABS_WARNING_PIN, OUTPUT);
+  pinMode(AIRBAG_PIN, OUTPUT);
+  pinMode(SPEED_SIGNAL_PIN, OUTPUT);
+  pinMode(IGNITION_ON_PIN, OUTPUT);
+  pinMode(ACCESSORY_MODE_PIN, OUTPUT);
+  pinMode(LIGHT_PIN, OUTPUT);
+
+  kbus.begin(9600, CSERIAL_8E1);
+  SPI.begin();
+  Serial.begin(115200);
+
+  CAN.reset();
+  CAN.setBitrate(CAN_500KBPS, MCP_8MHZ);
+  CAN.setNormalMode();
+}
+
+bool isValidFloat(String str) {
+  bool dotSeen = false;
+  for (unsigned int i = 0; i < str.length(); i++) {
+    char c = str.charAt(i);
+    if (i == 0 && (c == '-' || c == '+')) continue;
+    if (c == '.') {
+      if (dotSeen) return false;
+      dotSeen = true;
+    } else if (!isDigit(c)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+bool isBool(String str) {
+  return str == "0" || str == "1";
+}
+
+void parseSerial() {
+  while (Serial.available()) {
+    char c = Serial.read();
+    if (c == '\n' || c == '\r') {
+      serialBuffer.trim();
+
+      // Process all frames in buffer
+      int start = 0;
+      while ((start = serialBuffer.indexOf('<')) != -1) {
+        int end = serialBuffer.indexOf('>', start);
+        if (end == -1) break;
+
+        String frame = serialBuffer.substring(start + 1, end);
+        serialBuffer = serialBuffer.substring(end + 1); // trim processed
+
+        int sep = frame.indexOf(':');
+        if (sep > 0 && sep < frame.length() - 1) {
+          String key = frame.substring(0, sep);
+          String valStr = frame.substring(sep + 1);
+          valStr.trim();
+
+          if (key == "GEAR" && valStr.length() > 0) {
+            gear = valStr[0];
+          } else if (isBool(valStr)) {
+            bool flag = valStr == "1";
+            if (key == "IGN") ignition_on = flag;
+            else if (key == "ACC") accessory_on = flag;
+            else if (key == "ABS") abs_warning = flag;
+            else if (key == "AIRBAG") airbag_warning = flag;
+            else if (key == "PARK") parking_brake_engaged = flag;
+            else if (key == "HIGH") high_beam = flag;
+            else if (key == "FOGF") fog_rear = flag;
+            else if (key == "FOGR") fog_front = flag;
+            else if (key == "LEFT") blinker_left = flag;
+            else if (key == "RIGHT") blinker_right = flag;
+            else if (key == "BRR") tail_right = flag;
+            else if (key == "BRL") tail_left = flag;
+            else if (key == "FRR") head_right = flag;
+            else if (key == "FRL") head_left = flag;
+            else if (key == "CAR") interior_light = flag;
+            else if (key == "LIGHT") light_switch = flag;
+            else if (key == "ASC") asc_enabled = flag;
+            else if (key == "ENG") engine_light = flag;
+            else if (key == "EML") eml_warning = flag;
+            else if (key == "GASCAP") gas_cap_warning = flag;
+            else if (key == "HEAT") high_temp_warning = flag;
+            else if (key == "OIL") oil_warning = flag;
+            else if (key == "CHG") battery_warning = flag;
+            else if (key == "GEARBOX") gearbox_present = flag;
+          } else if (isValidFloat(valStr)) {
+            float val = valStr.toFloat();
+            if (key == "RPM") rpm = val;
+            else if (key == "SPEED") speed_kmh = val;
+            else if (key == "TEMP") temp_c = val;
+            else if (key == "FUEL") fuel_percent = val;
+            else if (key == "THROTTLE") throttle = val;
+          } else {
+            Serial.println("Invalid frame: <" + key + ":" + valStr + ">");
+          }
+          Serial.println("Parsed: " + key + "=" + valStr);
+        }
+      }
+
+      serialBuffer = "";
+    } else {
+      serialBuffer += c;
+    }
+  }
+}
+
+void loop() {
+  parseSerial();
+
+  digitalWrite(ABS_WARNING_PIN, abs_warning);
+  digitalWrite(AIRBAG_PIN, airbag_warning ? LOW : HIGH);
+  digitalWrite(IGNITION_ON_PIN, ignition_on ? LOW : HIGH);
+  digitalWrite(ACCESSORY_MODE_PIN, accessory_on ? LOW : HIGH);
+  digitalWrite(LIGHT_PIN, light_switch ? LOW : HIGH);
+  digitalWrite(PARKING_BRAKE_PIN, parking_brake_engaged ? LOW : HIGH);
+
+  if (millis() - last_can_update > 5) {
+    updateGearDisplay(CAN, gear, gearbox_present);
+    updateRPMNeedle(CAN, rpm);
+    updateSpeedNeedle(CAN, SPEED_SIGNAL_PIN, speed_kmh);
+    updateTemperatureGauge(CAN, temp_c);
+    updateASCLight(CAN, speed_kmh, asc_enabled ? 0 : 1);
+    updateWarningIndicators(CAN, engine_light, cruise_control, eml_warning, gas_cap_warning,
+                            high_temp_warning, oil_warning, battery_warning,
+                            throttle, temp_c, rpm, speed_kmh);
+    last_can_update = millis();
+  }
+
+  if (millis() - last_kbus_update > 50) {
+    bool lights1[] = {high_beam, fog_rear, fog_front, blinker_left, blinker_right};
+    bool lights2[] = {tail_right, tail_left, head_right, head_left, interior_light};
+    updateKbusLights(kbus, lights1, lights2);
+    last_kbus_update = millis();
+  }
+}

--- a/Arduino Code/E39_Cluster_SimHub/cluster_control_functions.cpp
+++ b/Arduino Code/E39_Cluster_SimHub/cluster_control_functions.cpp
@@ -1,0 +1,190 @@
+// Updated cluster_control_functions.cpp with improved function naming
+#include <Arduino.h>
+#include <mcp2515.h>
+#include "constants.h"
+#include <CustomSoftwareSerial.h>
+
+uint16_t fuel_consumption_total = 0;
+byte iso_checksum(byte *data, byte len) {
+  byte crc = 0;
+  for (byte i = 0; i < len; i++) {
+    crc ^= data[i];
+  }
+  return crc;
+}
+
+void sendKbusMessage(CustomSoftwareSerial &refSer, byte *data) {
+  int end_i = data[1] + 2;
+  data[end_i - 1] = iso_checksum(data, end_i - 1);
+  refSer.write(data, end_i + 1);
+}
+
+void sendCanMessage(MCP2515 &can_bus, uint16_t address, byte a, byte b, byte c, byte d, byte e, byte f, byte g, byte h) {
+  struct can_frame canMsg;
+  canMsg.can_id = address;
+  canMsg.can_dlc = 8;
+  canMsg.data[0] = a;
+  canMsg.data[1] = b;
+  canMsg.data[2] = c;
+  canMsg.data[3] = d;
+  canMsg.data[4] = e;
+  canMsg.data[5] = f;
+  canMsg.data[6] = g;
+  canMsg.data[7] = h;
+
+  const int maxRetries = 5;
+  byte result;
+  int attempt = 0;
+  do {
+    result = can_bus.sendMessage(&canMsg);
+    if (result == MCP2515::ERROR_OK) return;
+    delay(10);
+    attempt++;
+  } while (attempt < maxRetries);
+}
+
+void updateSpeedNeedle(MCP2515 &can_bus, uint8_t speed_signal_pin, int speed_kmh) {
+  if (speed_kmh < MIN_SPEED_KMH) {
+    noTone(speed_signal_pin);
+    return;
+  }
+  if (speed_kmh > MAX_SPEED_KMH) {
+    speed_kmh = MAX_SPEED_KMH;
+  }
+
+  // Improved frequency mapping — tuned for E39 cluster tone input
+  float tone_freq;
+  if (speed_kmh <= 20) {
+    tone_freq = 45 + speed_kmh * 3.6;
+  } else if (speed_kmh <= 40) {
+    tone_freq = 130 + (speed_kmh - 20) * 5.6;  // was 5.2
+  } else {
+    tone_freq = 238 + (speed_kmh - 40) * 7.5;  // was 6.8
+  }
+
+  tone(speed_signal_pin, static_cast<int>(tone_freq));
+}
+
+void updateRPMNeedle(MCP2515 &can_bus, int rpm_val) {
+  if (rpm_val > MAX_RPM) rpm_val = MAX_RPM;
+  if (rpm_val < MIN_RPM) rpm_val = MIN_RPM;
+
+  int rpm_scaled = int(RPM_GAIN * rpm_val) + RPM_OFFSET;
+  int rpm_lsb = rpm_scaled & 0x00FF;
+  int rpm_msb = (rpm_scaled >> 8) & 0xFF;
+
+  sendCanMessage(can_bus, 0x316, 0, 0, rpm_lsb, rpm_msb, 0, 0, 0, 0);
+}
+
+void updateTemperatureGauge(MCP2515 &can_bus, int temp_val) {
+  if (temp_val < MIN_TEMP) temp_val = MIN_TEMP;
+  if (temp_val > MAX_TEMP) temp_val = MAX_TEMP;
+  uint8_t temp_byte;
+  if (temp_val <= 90) {
+    temp_byte = map(temp_val, 70, 90, 0xA0, 0xB4); // cold to center
+  } else if (temp_val <= 95) {
+    temp_byte = 0xB4; // stabilized middle
+  } else {
+    temp_byte = map(temp_val, 100, 130, 225, 255);
+  }
+
+  // Use realistic CAN message for 0x329
+  sendCanMessage(can_bus, 0x329,
+    0x4F,           // Byte0: Bit1 set = TCU present
+    temp_byte,      // Byte1: Coolant temp
+    0x82,           // Byte2: Ambient pressure (safe value)
+    0x10,           // Byte3: Battery OK
+    0x00,           // Byte4: Engine running
+    0x20,           // Byte5: Throttle %
+    0xFF,           // Byte6: Fuel type = gasoline
+    0x00            // Byte7: filler
+  );
+}
+
+void updateKbusLights(CustomSoftwareSerial &refSer, bool *light_array1, bool *light_array2) {
+  byte LightByte1 = 0x00;
+  byte LightByte2 = 0x00;
+
+  for (int i = 0; i < 5; i++) {
+    if (light_array1[i]) LightByte1 |= 1 << (i + 2);
+    if (light_array2[i]) LightByte2 |= 1 << (i + 2);
+  }
+
+  if (light_array2[4]) LightByte2 |= 1 << 7;
+
+  byte light_array[] = {0xD0, 0x08, 0xBF, 0x5B, LightByte1, 0x00, 0x00, LightByte2, 0x00, 0x58, 0x00};
+  sendKbusMessage(refSer, light_array);
+
+  byte msg[] = {0x80, 0x04, 0xC0, 0x21, 0x00, 0x00};
+  sendKbusMessage(refSer, msg);
+}
+
+void updateWarningIndicators(MCP2515 &can_bus, int engine_light_state, int cruise_light_state, int EML_state,
+                             int gas_cap_light_state, int heat_light_state, int oil_light_state,
+                             int charge_light_state, float throttle, int temp_val, float rpm_val, float speed_val) {
+  uint8_t status1_byte = 0x00;
+  if (engine_light_state) status1_byte |= (1 << 1);
+  if (cruise_light_state) status1_byte |= (1 << 3);
+  if (EML_state) status1_byte |= (1 << 4);
+  if (gas_cap_light_state) status1_byte |= (1 << 6);
+
+  // Base fuel consumption from speed & RPM
+  int fuel_consumption =
+    map(throttle, 0, 100, 0, 220); // Throttle dominates
+
+  // RPM and speed only lightly contribute
+  fuel_consumption += map(rpm_val, 600, 6000, 1, 30);
+  fuel_consumption += map(speed_val, 0, 240, 1, 25);
+
+  // Extra fuel usage for aggressive driving
+  if (rpm_val > 5000 || speed_val > 180) fuel_consumption += 50;
+
+  fuel_consumption_total += fuel_consumption;
+  
+  uint8_t fuel_LSB = fuel_consumption_total & 0xFF;
+  uint8_t fuel_MSB = (fuel_consumption_total >> 8) & 0xFF;
+
+  if (temp_val >= (MAX_TEMP-10)) heat_light_state = 1;
+
+  int status_byte2 = (heat_light_state << 3) | (oil_light_state << 1);
+
+  sendCanMessage(can_bus, 0x545, status1_byte, fuel_LSB, fuel_MSB, status_byte2, 0x00, charge_light_state, 0x00, 0x00);
+}
+
+void updateASCLight(MCP2515 &can, float speedKph, bool asc_state) {
+  if (asc_state) {
+    uint16_t speed_val = (uint16_t)(speedKph * 256 / 8);
+    sendCanMessage(can, 0x153, 0x00, speed_val & 0xFF, (speed_val >> 8) & 0xFF, 0x00, 0x00, 0x00, 0x00, 0x00);
+  }
+}
+
+void updateGearDisplay(MCP2515 &can_bus, char gearChar, bool transmissionStatus) {
+  if (!transmissionStatus) return;
+
+  uint8_t gear_code;
+
+  switch (gearChar) {
+    case 'P': gear_code = 0x08; break;
+    case 'R': gear_code = 0x07; break;
+    case 'N': gear_code = 0x06; break;
+    case 'D': gear_code = 0x05; break;
+    case '4': gear_code = 0x04; break;
+    case '3': gear_code = 0x03; break;
+    case '2': gear_code = 0x02; break;
+    case '1': gear_code = 0x01; break;
+    case '5': gear_code = 0x09; break;
+    case 'O': gear_code = 0x0A; break; // display none without error
+    default:  return; // invalid input
+  }
+
+  sendCanMessage(can_bus, 0x43F,
+    0x81,        // Byte0
+    gear_code,   // Byte1: Gear selector
+    0xFF,        // Byte2: no mode
+    0xFF,        // Byte3
+    0x00,        // Byte4
+    0x80,        // Byte5: no warning
+    0xFF,        // Byte6
+    0x00         // Byte7
+  );
+}

--- a/Arduino Code/E39_Cluster_SimHub/cluster_control_functions.h
+++ b/Arduino Code/E39_Cluster_SimHub/cluster_control_functions.h
@@ -1,0 +1,43 @@
+
+#ifndef CLUSTER_CONTROL_FUNCTIONS_H
+#define CLUSTER_CONTROL_FUNCTIONS_H
+
+#include <mcp2515.h>
+#include <CustomSoftwareSerial.h>
+
+// Core CAN and K-Bus message functions
+void sendCanMessage(MCP2515 &can_bus, uint16_t address, byte a, byte b, byte c, byte d, byte e, byte f, byte g, byte h);
+void sendKbusMessage(CustomSoftwareSerial &refSer, byte *data);
+
+// Display + Gauge Updates
+void updateSpeedNeedle(MCP2515 &can_bus, uint8_t speed_signal_pin, int speed_kmh);
+void updateRPMNeedle(MCP2515 &can_bus, int rpm_val);
+void updateTemperatureGauge(MCP2515 &can_bus, int temp_val);
+
+// Gear and Shifter Display
+void updateGearDisplay(MCP2515 &can_bus, char gearChar, bool transmissionStatus);
+
+// Status Indicators (Cluster lights over CAN)
+void updateWarningIndicators(
+  MCP2515 &can_bus,
+  int engine_light_state,
+  int cruise_light_state,
+  int EML_state,
+  int gas_cap_light_state,
+  int heat_light_state,
+  int oil_light_state,
+  int charge_light_state,
+  float throttle,
+  int temp_val,
+  float rpm_val,
+  float speed_val
+);
+
+// ASC/ESP message
+void updateASCLight(MCP2515 &can, float speedKph, bool asc_state);
+
+// K-Bus Light Updates
+void updateKbusLights(CustomSoftwareSerial &refSer, bool *light_array1, bool *light_array2);
+
+#endif
+

--- a/Arduino Code/E39_Cluster_SimHub/constants.h
+++ b/Arduino Code/E39_Cluster_SimHub/constants.h
@@ -1,0 +1,18 @@
+#ifndef CONSTANTS_H
+#define CONSTANTS_H
+
+// RPM gauge range and conversion
+#define MAX_RPM        7000
+#define MIN_RPM        0
+#define RPM_GAIN       6.1786
+#define RPM_OFFSET     1321
+
+// Temperature range (used in updateTemperatureGauge)
+#define MIN_TEMP       30   // Minimum realistic coolant temperature
+#define MAX_TEMP       130  // Maximum before triggering overheat
+
+// Speed limits (in km/h)
+#define MIN_SPEED_KMH  6    // ~4 mph
+#define MAX_SPEED_KMH  263  // ~163 mph
+
+#endif

--- a/Arduino Code/E39_Cluster_SimHub/pin_definitions.h
+++ b/Arduino Code/E39_Cluster_SimHub/pin_definitions.h
@@ -1,0 +1,15 @@
+#ifndef PIN_DEFINITIONS_H
+#define PIN_DEFINITIONS_H
+
+// Digital Output Pins (Cluster control)
+#define IGNITION_ON_PIN       2
+#define ACCESSORY_MODE_PIN    3
+#define ABS_WARNING_PIN       4
+#define PARKING_BRAKE_PIN     5
+#define K_BUS_PIN             7
+#define SPEED_SIGNAL_PIN      8
+#define CS_PIN                9
+#define AIRBAG_PIN            A2
+#define LIGHT_PIN             A3
+
+#endif

--- a/Arduino Code/E39_Cluster_Test/E39_Cluster_Test.ino
+++ b/Arduino Code/E39_Cluster_Test/E39_Cluster_Test.ino
@@ -1,0 +1,419 @@
+// Includes for program
+#include <SPI.h>
+#include <mcp2515.h>
+#include "constants.h"
+#include "pin_definitions.h"
+#include <CustomSoftwareSerial.h>
+
+// C File Includes
+#include "cluster_control_functions.h"
+
+// Defines for program
+#define DEBUG_VALUES true
+
+// MCP2515 Instantiation
+#define CS_PIN 9
+#define IRQ_PIN 2  // Optional, only needed if you're using interrupts
+
+MCP2515 CAN(CS_PIN);
+CustomSoftwareSerial kbus(255, 7);
+
+// Global variables that are changed in the main loop, and initializing certian states
+unsigned long lastMsgTime = 0;
+uint8_t fuel_val;
+uint8_t abs_warning_state;
+int speed_val;
+uint8_t ignition_state;
+uint8_t accessory_state;
+
+byte gearIndex = 0;
+uint16_t fuelConsumptionCounter = 0;
+unsigned long lastMPGUpdate = 0;
+float rpm_val;
+int temp_val;
+int mpg_val;
+int engine_light_state;
+int cruise_light_state;
+int EML_state;
+int gas_cap_light_state;
+int heat_light_state;
+int charge_light_state;
+int park_brake_state;
+int oil_light_state;
+bool high_beam_state;
+bool gearbox_state = 1;
+bool fog_rear_state;
+bool fog_front_state;
+bool left_blinker_state;
+bool right_blinker_state;
+bool back_right_light_state;
+bool back_left_light_state;
+bool front_right_light_state;
+bool front_left_light_state;
+bool car_light_state;
+bool light_state;
+bool asc_state;
+bool airbag_state;
+int lightIndex = 0;
+unsigned long lastLight = 0;
+
+int fuel_consumption_val;
+int rate_var;
+int loopCounter = 0;
+int lastGearTime = 0;
+
+
+void setup() {
+
+  // Sensor Initialization
+  accessory_state = 0;
+  ignition_state = 0;
+  fuel_val = 50;
+  park_brake_state = 1;
+  abs_warning_state = 0;
+  airbag_state = 0;
+  asc_state = 1;
+  temp_val = 275;
+  rpm_val = 1000;
+
+  // E46 Cluster Control Pin Setup
+  pinMode(PARKING_BRAKE_PIN, OUTPUT);
+  pinMode(LIGHT_PIN, OUTPUT);
+  pinMode(ABS_WARNING_PIN, OUTPUT);
+  pinMode(AIRBAG_PIN, OUTPUT);
+  pinMode(SPEED_SIGNAL_PIN, OUTPUT);
+  pinMode(IGNITION_ON_PIN, OUTPUT);
+  pinMode(ACCESSORY_MODE_PIN, OUTPUT);
+
+  // Set SPI Select pins low to start
+  //digitalWrite(DIGI_POT_CS, HIGH);
+  kbus.begin(9600, CSERIAL_8E1); 
+
+  // Setup SPI for communication
+  SPI.begin();
+
+  // Serial Debug Communication
+  Serial.begin(115200);  // Use fast baud for clearer debugging
+  while (!Serial);       // Wait for Serial to be ready on boards like Leonardo
+
+  Serial.println("Initializing CAN...");
+
+  CAN.reset();  // Reset controller
+
+  // Set bitrate to 500 kbps for 16 MHz crystal
+  if (CAN.setBitrate(CAN_500KBPS, MCP_8MHZ) == MCP2515::ERROR_OK) {
+    Serial.println("Bitrate set to 500kbps.");
+  } else {
+    Serial.println("Failed to set CAN bitrate.");
+    while (1);  // Stop if bitrate setting fails
+  }
+
+  // Set to normal operating mode
+  if (CAN.setNormalMode() == MCP2515::ERROR_OK) {
+    Serial.println("CAN controller set to Normal Mode.");
+  } else {
+    Serial.println("Failed to set CAN controller to Normal Mode.");
+    while (1);  // Stop if mode setting fails
+  }
+
+  Serial.println("CAN initialization successful.");
+}
+
+void loop() {
+  // Setup the serial monitor to inject values into the program
+  if(Serial.available()) {
+    String data_type = Serial.readStringUntil(':');
+
+    if(data_type == "speed") {
+      String arg_str = Serial.readStringUntil('\n');
+      speed_val = arg_str.toInt();
+    }
+    else if(data_type == "rpm") {
+      String arg_str = Serial.readStringUntil('\n');
+      rpm_val = arg_str.toInt();
+    }
+    else if(data_type == "temp") {
+      String arg_str = Serial.readStringUntil('\n');
+      temp_val = arg_str.toInt();
+    }
+    else if (data_type == "ignition") {
+      String arg_str = Serial.readStringUntil('\n');
+      ignition_state = arg_str.toInt();
+    }
+    else if (data_type == "accessory") {
+      String arg_str = Serial.readStringUntil('\n');
+      accessory_state = arg_str.toInt();
+    }
+    else if(data_type == "fuel") {
+      String arg_str = Serial.readStringUntil('\n');
+      fuel_val = arg_str.toInt();
+    }
+    else if (data_type == "ABS_Warning") {
+      String arg_str = Serial.readStringUntil('\n');
+      abs_warning_state = arg_str.toInt();
+    }
+    else if (data_type == "airbag") {
+      String arg_str = Serial.readStringUntil('\n');
+      airbag_state = arg_str.toInt();
+    }
+    else if(data_type == "eLight") {
+      String arg_str = Serial.readStringUntil('\n');
+      engine_light_state = arg_str.toInt();
+    }
+    else if(data_type == "emlLight") {
+      String arg_str = Serial.readStringUntil('\n');
+      EML_state = arg_str.toInt();
+    }
+    else if(data_type == "gasCapLight") {
+      String arg_str = Serial.readStringUntil('\n');
+      gas_cap_light_state = arg_str.toInt();
+    }
+    else if(data_type == "heatLight") {
+      String arg_str = Serial.readStringUntil('\n');
+      heat_light_state = arg_str.toInt();
+    }
+    else if(data_type == "oilLight") {
+      String arg_str = Serial.readStringUntil('\n');
+      oil_light_state = arg_str.toInt();
+    }
+    else if(data_type == "chgLight") {
+      String arg_str = Serial.readStringUntil('\n');
+      charge_light_state = arg_str.toInt();
+    }
+    else if(data_type == "hbrakeLight") {
+      String arg_str = Serial.readStringUntil('\n');
+      park_brake_state = arg_str.toInt();
+    }
+    else if(data_type == "highBeam") {
+      String arg_str = Serial.readStringUntil('\n');
+      high_beam_state = arg_str.toInt();
+    }
+    else if(data_type == "gearbox") {
+      String arg_str = Serial.readStringUntil('\n');
+      gearbox_state = arg_str.toInt();
+    }
+    else if(data_type == "fogRear") {
+      String arg_str = Serial.readStringUntil('\n');
+      fog_rear_state = arg_str.toInt();
+    }
+    else if(data_type == "fogFront") {
+      String arg_str = Serial.readStringUntil('\n');
+      fog_front_state = arg_str.toInt();
+    }
+    else if(data_type == "leftBlink") {
+      String arg_str = Serial.readStringUntil('\n');
+      left_blinker_state = arg_str.toInt();
+    }
+    else if(data_type == "rightBlink") {
+      String arg_str = Serial.readStringUntil('\n');
+      right_blinker_state = arg_str.toInt();
+    }
+    else if(data_type == "backRightLight") {
+      String arg_str = Serial.readStringUntil('\n');
+      back_right_light_state = arg_str.toInt();
+    }
+    else if(data_type == "backLeftLight") {
+      String arg_str = Serial.readStringUntil('\n');
+      back_left_light_state = arg_str.toInt();
+    }
+    else if(data_type == "frontRightLight") {
+      String arg_str = Serial.readStringUntil('\n');
+      front_right_light_state = arg_str.toInt();
+    }
+    else if(data_type == "frontLeftLight") {
+      String arg_str = Serial.readStringUntil('\n');
+      front_left_light_state = arg_str.toInt();
+    }
+    else if(data_type == "carLight") {
+      String arg_str = Serial.readStringUntil('\n');
+      car_light_state = arg_str.toInt();
+    }
+    else if(data_type == "light") {
+      String arg_str = Serial.readStringUntil('\n');
+      light_state = arg_str.toInt();
+    }
+    else if(data_type == "ascLight") {
+      String arg_str = Serial.readStringUntil('\n');
+      asc_state = arg_str.toInt();
+    }
+    else {
+      // Flush the rest of the data
+      Serial.print('\n');
+    }
+
+      // Debugger Print out
+#if DEBUG_VALUES
+    Serial.print("fuel: ");
+    Serial.println(fuel_val);
+
+    Serial.print("ABS_Warning: ");
+    Serial.println(abs_warning_state);
+
+    Serial.print("airbag: ");
+    Serial.println(airbag_state);
+
+    Serial.print("ignition: ");
+    Serial.println(ignition_state);
+
+    Serial.print("accessory: ");
+    Serial.println(accessory_state);
+    
+    Serial.print("rpm: ");
+    Serial.println(rpm_val);
+    
+    Serial.print("speed: ");
+    Serial.println(speed_val);
+    
+    Serial.print("temp: ");
+    Serial.println(temp_val);
+    
+    Serial.print("mpg: ");
+    Serial.println(mpg_val);
+
+    Serial.print("Temperature Val: ");
+    Serial.println(temp_val);
+
+    Serial.print("eLight: ");
+    Serial.println(engine_light_state);
+
+    Serial.print("emlLight: ");
+    Serial.println(EML_state);
+
+    Serial.print("gasCapLight: ");
+    Serial.println(gas_cap_light_state);
+
+    Serial.print("heatLight: ");
+    Serial.println(heat_light_state);
+
+    Serial.print("oilLight: ");
+    Serial.println(oil_light_state);
+
+    Serial.print("chgLight: ");
+    Serial.println(charge_light_state);
+
+    Serial.print("hbrakeLight: ");
+    Serial.println(park_brake_state);
+
+    Serial.print("highBeam: ");
+    Serial.println(high_beam_state);
+
+    Serial.print("gearbox: ");
+    Serial.println(gearbox_state);
+
+    Serial.print("fogRear: ");
+    Serial.println(fog_rear_state);
+
+    Serial.print("fogFront: ");
+    Serial.println(fog_front_state);
+
+    Serial.print("leftBlink: ");
+    Serial.println(left_blinker_state);
+
+    Serial.print("rightBlink: ");
+    Serial.println(right_blinker_state);
+
+    Serial.print("backRightLight: ");
+    Serial.println(back_right_light_state);
+
+    Serial.print("backLeftLight: ");
+    Serial.println(back_left_light_state);
+
+    Serial.print("frontRightLight: ");
+    Serial.println(front_right_light_state);
+
+    Serial.print("frontLeftLight: ");
+    Serial.println(front_left_light_state);
+
+    Serial.print("carLight: ");
+    Serial.println(car_light_state);
+
+    Serial.print("light: ");
+    Serial.println(light_state);
+
+    Serial.print("ascLight: ");
+    Serial.println(asc_state);
+    
+    Serial.println();
+    
+#endif
+  }
+  // Configure all of the digital outputs
+  digitalWrite(ABS_WARNING_PIN, abs_warning_state);
+  digitalWrite(AIRBAG_PIN, airbag_state);
+  digitalWrite(IGNITION_ON_PIN, ignition_state);
+  digitalWrite(ACCESSORY_MODE_PIN, accessory_state);
+  digitalWrite(LIGHT_PIN, light_state);
+  digitalWrite(PARKING_BRAKE_PIN, park_brake_state);
+
+  
+  if (millis() - lastGearTime > 2000) {
+    gearIndex += 1;
+    if(gearIndex == 5) {
+      gearIndex = 0;
+    }
+    lastGearTime = millis();
+  }
+  sendGear(CAN, gearIndex, gearbox_state);
+  
+  // setFuel(DIGI_POT_CS, fuel_val); NOT READY YET
+  setRPM(CAN, rpm_val);
+  delay(2);
+  setSpeedometer(CAN, SPEED_SIGNAL_PIN, speed_val);
+  delay(2);
+  setTemp(CAN, temp_val);
+  delay(2);
+  sendASC(CAN, speed_val, asc_state);
+  delay(2);
+  // Simulate fuel usage based on speed and rpm
+  unsigned long now = millis();
+  if (now - lastMPGUpdate > 20) { // update 50x per second
+    lastMPGUpdate = now;
+
+    // Simulate really aggressive fuel use
+    int usage = map(speed_val, 0, 240, 5, 180) + map(rpm_val, 600, 6000, 5, 220);
+
+    // Optional boost: simulate full throttle load
+    if (rpm_val > 5000 || speed_val > 180) {
+      usage += 100;
+    }
+
+    fuelConsumptionCounter += usage;
+  }
+
+  set_status_lights1(
+    CAN,
+    engine_light_state,
+    cruise_light_state,
+    EML_state,
+    gas_cap_light_state,
+    heat_light_state,
+    oil_light_state,
+    charge_light_state,
+    fuelConsumptionCounter
+  );
+
+
+  struct can_frame incoming;
+
+  // Check for any incoming CAN messages
+  if (CAN.readMessage(&incoming) == MCP2515::ERROR_OK) {
+    
+    // 🧠 Look for the 0x615 "request" frame from IKE
+    if (incoming.can_id == 0x615) {
+      // Optional: debug print
+      // 📤 Send your response — handbrake OFF
+      //sendClusterFeedback(CAN, 000016, 0x2A, temp_val, park_brake_state); // NO VISIBLE CHANGE YET
+    }
+  }
+
+  if(loopCounter >=50) {
+    // Packing up data to send to kbus function
+    bool light_array1[] = {high_beam_state, fog_rear_state, fog_front_state, left_blinker_state, right_blinker_state};
+    bool light_array2[] = {back_right_light_state, back_left_light_state, front_right_light_state, front_left_light_state, car_light_state};
+    set_kbus_lights(kbus, light_array1, light_array2);
+    // Reset counter
+    loopCounter = 0;
+  }
+  loopCounter += 1;
+  delay(1);
+}

--- a/Arduino Code/E39_Cluster_Test/cluster_control_functions.cpp
+++ b/Arduino Code/E39_Cluster_Test/cluster_control_functions.cpp
@@ -1,0 +1,302 @@
+// Includes for program
+#include <Arduino.h>
+#include <mcp2515.h>
+#include "constants.h"
+#include <CustomSoftwareSerial.h>
+
+/*
+ * The following two funcitons (iso_checksum() and sendKbus were solely derived by the work on Neuros-Projekte:
+ * https://neuros-projekte.de/simulator/bmw-e46-arduino-simhub/
+ */
+
+byte iso_checksum(byte *data, byte len)//len is the number of bytes (not the # of last byte)
+{
+  byte crc=0;
+  for(byte i=0; i<len; i++)
+  {    
+    crc=crc^data[i];
+  }
+  return crc;
+}
+
+void sendKbus(CustomSoftwareSerial &refSer, byte *data) {
+  int end_i = data[1]+2 ;
+  data[end_i-1] = iso_checksum(data, end_i-1);
+  refSer.write(data, end_i + 1);
+}
+
+// Function used to send all CAN messages
+void CAN_Send(MCP2515 &can_bus, uint16_t address, byte a, byte b, byte c, byte d, byte e, byte f, byte g, byte h){
+  struct can_frame canMsg1;
+
+  canMsg1.can_id  = address;
+  canMsg1.can_dlc = 8;
+  canMsg1.data[0] = a;
+  canMsg1.data[1] = b;
+  canMsg1.data[2] = c;
+  canMsg1.data[3] = d;
+  canMsg1.data[4] = e;
+  canMsg1.data[5] = f;
+  canMsg1.data[6] = g;
+  canMsg1.data[7] = h;
+  
+  const int maxRetries = 5;
+  byte result;
+  int attempt = 0;
+
+  do {
+    result = can_bus.sendMessage(&canMsg1);
+    if (result == MCP2515::ERROR_OK) {
+      //Serial.println("CAN message sent successfully.");
+      return;
+    } else if (result == MCP2515::ERROR_ALLTXBUSY) {
+      Serial.println("TX buffers busy, retrying...");
+      delay(50);  // wait a bit before retrying
+    } else {
+      Serial.print("Error sending CAN message: ");
+      Serial.println(result);
+      return;
+    }
+    attempt++;
+  } while (attempt < maxRetries);
+
+  //Serial.println("Failed to send CAN message after retries.");
+}
+
+void sendKeepAlive(MCP2515 &can_bus) {
+  // Not well documented, but needed
+  uint8_t data[8] = {0x00, 0x00, 0x00, 0x40, 0x00, 0x00, 0x00, 0x00};
+  CAN_Send(can_bus, 0x130, data[0], data[1], data[2], data[3], data[4], data[5], data[6], data[7]);
+}
+
+void sendClusterFeedback(MCP2515 &can, int odoKm = 123456, int fuelHex = 0x2A, int tempC = 20, int handbrakeOn = 0) {
+  // Odometer: 12345 → 1234 (×10) = 12340 → 0x3034
+  uint16_t odo = odoKm / 10;
+  uint16_t minutes = 3000;  // running clock: 50h
+  CAN_Send(can, 0x613, odo & 0xFF, (odo >> 8) & 0xFF, fuelHex, minutes & 0xFF, handbrakeOn ? 0x02 : 0x00, 0x00, 0x00, 0x00);
+}
+
+// Gear encoding for CAN message 0x43F
+const uint8_t gearCanCodes[] = {
+  0x00, // P
+  0x70, // R
+  0x20, // N
+  0x30, // D
+  0x10, // 1
+  0x20, // 2
+  0x30, // 3
+  0x40, // 4
+  0x50  // 5
+};
+
+uint8_t egsAliveCounter = 0;
+
+void sendGear(MCP2515 &can_bus, uint8_t gearIndex, bool transmissionStatus) {
+  if (!transmissionStatus || gearIndex >= sizeof(gearCanCodes)) return;
+
+  uint8_t gearByte = gearCanCodes[gearIndex];
+  uint8_t gearNumber = gearIndex >= 4 ? (gearIndex - 3) : 0; // gear number for manual display
+
+  // Send 0x43F – Transmission gear status
+  CAN_Send(can_bus, 0x43F,
+           gearByte,         // Byte 0: Current gear with engagement flags
+           0x00,             // Byte 1: Torque limit (optional)
+           0x00,             // Byte 2: Mode flags (D/S/M)
+           0x00,             // Byte 3: Reserved / gear mode
+           0x00,             // Byte 4: Optional torque req
+           0x00,             // Byte 5: Unused
+           0x00,             // Byte 6: Reserved
+           egsAliveCounter++); // Byte 7: Alive counter
+
+  // Send 0x43B – Shifter position (lever)
+  uint8_t selectorByte = gearIndex == 0 ? 0x70 :  // Park
+                         gearIndex == 1 ? 0x60 :  // Reverse
+                         gearIndex == 2 ? 0x20 :  // Neutral
+                         gearIndex == 3 ? 0x10 :  // Drive
+                         0x08;                    // Manual mode
+
+  CAN_Send(can_bus, 0x43B,
+           selectorByte,       // Byte 0: Shifter position
+           egsAliveCounter,    // Byte 1: Alive counter
+           0x00, 0x00, 0x00, 0x00, 0x00, 0x00);
+}
+
+// This function sets the tone frequency on the desired pin the correct value for the 
+// user's desired speed value (in miles-per-hour)
+void setSpeedometer(MCP2515 &can_bus, uint8_t speed_signal_pin, int speed_val) {
+  /* 
+   The minimum value 'tone()' can be sent is 31, which corresponds to a speed of 3.188 MPH
+   To be conservative, we set the minimum settable speed at 4 MPH. In addition, the max
+   displayable speed (where the arm on the speedometer ceases to move further) is about
+   163 MPH, so this is what the cap is set to.
+  */
+  if(speed_val <= MIN_SPEED) {
+    speed_val = MIN_SPEED;
+  }
+  else if(speed_val > MAX_SPEED) {
+    speed_val = MAX_SPEED;
+  }
+
+  // Two linear functions to define the two ranges of relative linearity, and limiting the minimum value sent to 35
+  float tone_freq;
+  if (speed_val < 10) {
+    tone_freq = 35;
+  }
+  else if(speed_val < 25) {
+    // Refer to the generated lookup table
+    tone_freq = 10.121 * speed_val - 4.823;
+  }
+  else {
+    tone_freq = 10.787 * speed_val - 26.03;
+  }
+
+  //float tone_freq = 10.718 * speed_val - 3.1716;
+  tone(speed_signal_pin, int(tone_freq));
+
+}
+
+void setRPM(MCP2515 &can_bus, int rpm_val) {
+  // Threshold the RPM value
+  if(rpm_val > MAX_RPM) {
+    rpm_val = MAX_RPM;
+  }
+  else if(rpm_val < MIN_RPM) {
+    rpm_val = MIN_RPM;
+  }
+
+  // Scale and offset the RPM value to convert to the value we send to the cluster
+  int rpm_val_int = int(RPM_GAIN*rpm_val) + RPM_OFFSET;
+  
+  // Convert the rpm value to two 8-bit integers
+  int rpm_lsb = rpm_val_int & 0x00FF;
+  int rpm_msb = (rpm_val_int & 0xFF00) >> 8;
+
+  // Setup the can message
+  CAN_Send(can_bus, 0x316, 0, 0, rpm_lsb, rpm_msb, 0, 0, 0, 0);
+}
+
+void setTemp(MCP2515 &can_bus, int temp_val) {
+  // Setting thersholds
+  if(temp_val < MIN_TEMP) {
+    temp_val = MIN_TEMP;
+  }
+  else if(temp_val > MAX_TEMP) {
+    temp_val = MAX_TEMP;
+  }
+
+  // Convert the temperature from float to an int
+  uint8_t temp_byte = temp_val + 48.373;
+  
+  // Setup the can message
+  CAN_Send(can_bus, 0x329, 0x00, temp_byte, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00);
+  
+}
+
+// This may not be extremely accurate for now, but will work ok
+void setFuel(uint8_t chip_select_pin, uint8_t fuel_percent) {
+  // Threshold the fuel value
+  if(fuel_percent > 100) {
+    fuel_percent = 100;
+  }
+
+  // Equation to convert from percentage to digi-pot value
+  float digipot_val_f = -1.88 * fuel_percent + 205;
+  uint8_t digipot_val_int = digipot_val_f;
+
+  // Iterate through resistance values
+  digitalWrite(chip_select_pin, LOW);
+  SPI.transfer(0x00);
+  SPI.transfer(digipot_val_int);
+  digitalWrite(chip_select_pin, HIGH);
+  //delay(100);
+
+  digitalWrite(chip_select_pin, LOW);
+  SPI.transfer(0x10);
+  SPI.transfer(digipot_val_int);
+  digitalWrite(chip_select_pin, HIGH);
+}
+
+// This functions handles illuminating all of the lights that are controlled over
+// the KBUS (which inclues the 
+void set_kbus_lights(CustomSoftwareSerial &refSer, bool *light_array1, bool *light_array2) {
+  // Take the light arrays, and process them into the actual byte we will send
+  byte LightByte1 = 0x00;
+  byte LightByte2 = 0x00;
+  
+  for(int i = 0; i < 5; i++) {
+    bool light1_val = light_array1[i];
+    if(light1_val) {
+      LightByte1 |= light1_val << (i+2);
+    }
+    else {
+      LightByte1 &= ~(light1_val << (i+2));
+    }
+
+    bool light2_val = light_array2[i];
+    if(light2_val) {
+      LightByte2 |= light2_val << (i+2);
+    }
+    else {
+      LightByte2 &= ~(light2_val << (i+2));
+    }
+  }
+
+  // Handler the lit up car separately
+  int car_light = light_array2[4];
+  if(car_light) {
+    LightByte2 |= 1 << 7;
+  }
+  else {
+    LightByte2 &= ~(1 << 7);
+  }
+  
+  // Define the arrays that actually get sent over the kbus
+  byte light_array[] = {0xD0, 0x08, 0xBF, 0x5B, LightByte1, 0x00, 0x00, LightByte2, 0x00, 0x58, 0x00};
+  sendKbus(refSer, light_array);
+
+  byte msg[] = {
+    0x80,  // Source: GM5
+    0x04,  // Length
+    0xC0,  // Destination: IKE
+    0x21,  // Status command (GM5 -> IKE status flags)
+    0x00,  // Handbrake bit OFF (value 0x01 = on, 0x00 = off)
+    0x00   // Checksum placeholder
+  };
+
+  sendKbus(refSer, msg);
+}
+
+void set_status_lights1(MCP2515 &can_bus, int engine_light_state, int cruise_light_state, int EML_state, int gas_cap_light_state, int heat_light_state, int oil_light_state, int charge_light_state, int fuel_consumption) {
+  // Initialize status_byte
+  uint8_t status1_byte = 0x00;
+  
+  // Reject false engine light inputs
+  if(engine_light_state){
+     status1_byte |= (1 << 1);
+  }
+  if(cruise_light_state) {
+     status1_byte |= (1 << 3);
+  }
+  if(EML_state) {
+     status1_byte |= (1 << 4);
+  }
+  if(gas_cap_light_state) {
+     status1_byte |= (1 << 6);
+  }
+
+  // MPG needle control – Byte 1 & 2
+  uint8_t fuel_LSB = fuel_consumption & 0xFF;
+  uint8_t fuel_MSB = (fuel_consumption >> 8) & 0xFF;
+  
+  int status_byte2 = (heat_light_state<<3)|(oil_light_state<<1);
+  CAN_Send(can_bus, 0x545, status1_byte, fuel_LSB, fuel_MSB, status_byte2, 0x00, charge_light_state, 0x00, 0x00);
+  
+}
+
+
+void sendASC(MCP2515 &can, float speedKph, bool asc_state) {
+  if(asc_state) {
+    uint16_t speed_val = (uint16_t)(speedKph * 256 / 8); // 1 km/h = 0x0008
+    CAN_Send(can, 0x153, 0x00, speed_val & 0xFF, (speed_val >> 8) & 0xFF, 0x00, 0x00, 0x00, 0x00, 0x00);
+  }
+}

--- a/Arduino Code/E39_Cluster_Test/cluster_control_functions.h
+++ b/Arduino Code/E39_Cluster_Test/cluster_control_functions.h
@@ -1,0 +1,12 @@
+// Extern references to get these functions to the main program
+extern void setSpeedometer(MCP2515 &can_bus, uint8_t speed_signal_pin, int speed_val);
+extern void sendKeepAlive(MCP2515 &can_bus);
+extern void setRPM(MCP2515 &can_bus, int rpm_val);
+extern void setTemp(MCP2515 &can_bus, int temp_val);
+extern void setFuel(uint8_t chip_select_pin, uint8_t fuel_percent);
+extern void set_kbus_lights(CustomSoftwareSerial &refSer, bool *light_array1, bool *light_array2);
+extern void set_status_lights1(MCP2515 &can_bus, int engine_light_state, int cruise_light_state, int EML_state, int gas_cap_light_state, int heat_light_state, int oil_light_state, int charge_light_state, int fuel_consumption);
+extern void sendASC(MCP2515 &can, float speedKph, bool asc_state);
+extern void sendClusterFeedback(MCP2515 &can, int odoKm = 000016, int fuelHex = 0x2A, int tempC = 20, int handbrakeOn = 0);
+extern void setMPG(int mpg_val);
+extern void sendGear(MCP2515 &can_bus, uint8_t gearIndex, bool transmissionStatus);

--- a/Arduino Code/E39_Cluster_Test/constants.h
+++ b/Arduino Code/E39_Cluster_Test/constants.h
@@ -1,0 +1,18 @@
+
+// Max and min speedometer values
+#define MAX_SPEED 163 // MPH
+#define MIN_SPEED 1 // MPH
+
+// Max and min temperature values
+#define MAX_TEMP 405 // Degrees Celcius
+#define MIN_TEMP 65  // Degrees Celcius
+
+// Max and min RPM values
+#define MAX_RPM 7000
+#define MIN_RPM 0
+#define RPM_GAIN 6.1786
+#define RPM_OFFSET 1321
+
+// Fuel constants
+#define R1_VALUE 330
+#define R_POT_MAX 5000

--- a/Arduino Code/E39_Cluster_Test/pin_definitions.h
+++ b/Arduino Code/E39_Cluster_Test/pin_definitions.h
@@ -1,0 +1,11 @@
+// Outputs
+#define PARKING_BRAKE_PIN 5
+#define ABS_WARNING_PIN 4 
+#define AIRBAG_PIN A2
+#define SPEED_SIGNAL_PIN 8
+#define LIGHT_PIN A3
+#define IGNITION_ON_PIN 2 
+#define ACCESSORY_MODE_PIN 3
+
+// SPI Pins
+#define DIGI_POT_CS 53


### PR DESCRIPTION
### Summary

This PR adds support for the BMW E39 (Low IKE) instrument cluster alongside the existing E46 functionality. It includes updates to the README with full E39 pinout tables, feature compatibility, CAN/K-Bus insights, and updated usage notes. The same Arduino shield and circuits can now drive both clusters with minor configuration differences. Also added is documentation for controlling the MPG gauge, gear indicators, and various warning lights via CAN and K-Bus.

Key additions:
- ✅ E39 cluster support (speed, RPM, lights, MPG, gear, etc.)
- 📄 Full E39 pinout added to README
- 🧠 New research insights on CAN IDs and MPG gauge behavior
- ♻️ Reuse of E46 K-Bus circuit for E39

Tested with E39 Low IKE and verified compatibility with SimHub + Arduino integration.
